### PR TITLE
added .fbx support using three.js's built-in FBXLoader

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -198,5 +198,16 @@ class ExtendedFileSupportSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 					this.plugin.toggleExtension("stl", value);
 				}));
+
+		new Setting(containerEl)
+			.setName(".fbx")
+			.setDesc("Autodesk FBX format, commonly used for 3d models and animations.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.fbx)
+				.onChange(async (value) => {
+					this.plugin.settings.fbx = value;
+					await this.plugin.saveSettings();
+					this.plugin.toggleExtension("fbx", value);
+				}));
 	}
 }

--- a/src/extensions/fbx.ts
+++ b/src/extensions/fbx.ts
@@ -1,0 +1,27 @@
+import { ThreeJSComponent, ThreeJSView } from "src/abstractions/threejsComponent";
+import { ExtensionComponent } from "src/extensionComponent";
+import { FBXLoader } from "three/examples/jsm/Addons.js";
+
+export const VIEW_TYPE_FBX = "extended-file-support-FBX";
+
+export class FBXComponent extends ThreeJSComponent {
+	loadModel(resource: string): void {
+		const loader = new FBXLoader();
+		loader.load(resource, (fbx) => {
+			this.scaleGroup(fbx);
+			this.centerGroup(fbx);
+
+			this.scene?.add(fbx);
+		})
+	}
+}
+
+export class FBXView extends ThreeJSView<FBXComponent> {
+	getComponent(): new (...args: ConstructorParameters<typeof ExtensionComponent>) => FBXComponent {
+		return FBXComponent;
+	}
+
+	getViewType(): string {
+		return VIEW_TYPE_FBX;
+	}
+}

--- a/src/extensionsRegistry.ts
+++ b/src/extensionsRegistry.ts
@@ -7,6 +7,7 @@ import { PSDComponent, PSDView, VIEW_TYPE_PSD } from "./extensions/psd"
 import { CLIPComponent, CLIPView, VIEW_TYPE_CLIP } from "./extensions/clip"
 import { STLComponent, STLView, VIEW_TYPE_STL } from "./extensions/stl"
 import { AIComponent, AIView, VIEW_TYPE_AI } from "./extensions/ai"
+import { FBXComponent, FBXView, VIEW_TYPE_FBX } from "./extensions/fbx"
 
 export type Extension = {
 	types: string[],
@@ -24,4 +25,5 @@ export const EXTENSION_REGISTRY: Extension[] = [
 	{ types: ["psd"], view_type: VIEW_TYPE_PSD, view: PSDView, component: PSDComponent },
 	{ types: ["stl"], view_type: VIEW_TYPE_STL, view: STLView, component: STLComponent },
 	{ types: ["ai"], view_type: VIEW_TYPE_AI, view: AIView, component: AIComponent },
+	{ types: ["fbx"], view_type: VIEW_TYPE_FBX, view: FBXView, component: FBXComponent },
 ]

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export interface ExtendedFileSupportSettings {
 	gltf: boolean;
 	glb: boolean;
 	stl: boolean;
+	fbx: boolean;
 }
 
 export const DEFAULT_SETTINGS: ExtendedFileSupportSettings = {
@@ -25,4 +26,5 @@ export const DEFAULT_SETTINGS: ExtendedFileSupportSettings = {
 	gltf: true,
 	glb: true,
 	stl: true,
+	fbx: true,
 }


### PR DESCRIPTION
- New src/extensions/fbx.ts mirroring the GLB/OBJ/STL pattern
- Registered it in src/extensionsRegistry.ts
- Added fbx toggle to src/settings.ts and the settings tab in main.ts